### PR TITLE
The CLI can now resolve shared fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "rollup-plugin-babel": "2.7.1",
     "rollup-plugin-commonjs": "8.0.2",
     "rollup-plugin-multi-entry": "2.0.1",
-    "rollup-plugin-node-resolve": "3.0.0"
+    "rollup-plugin-node-resolve": "3.0.0",
+    "tmp": "0.0.31"
   },
   "dependencies": {
     "babel-generator": "6.25.0",

--- a/rollup-cli.config.js
+++ b/rollup-cli.config.js
@@ -7,6 +7,7 @@ const pkg = require('./package.json');
 
 const external = Object.keys(pkg.dependencies).concat(
   'graphql/utilities',
+  'graphql/language',
   'graphql-js-client/dev',
   'module',
   'fs',

--- a/rollup-cli.config.js
+++ b/rollup-cli.config.js
@@ -23,7 +23,7 @@ Version: ${pkg.version} Commit: ${revision}
 */`;
 
 export default {
-  entry: 'src/cli.js',
+  entry: 'src/cli-executor.js',
   plugins: [
     babel({
       presets: [

--- a/src/cli-controller.js
+++ b/src/cli-controller.js
@@ -1,5 +1,5 @@
 import minimist from 'minimist';
-import {join, normalize} from 'path';
+import {join, normalize, isAbsolute} from 'path';
 import {readFileSync} from 'fs';
 import {
   compileToModule,
@@ -10,6 +10,10 @@ import {
 } from './index';
 
 function normalizePath(filename) {
+  if (isAbsolute(filename)) {
+    return normalize(filename);
+  }
+
   return normalize(join(process.cwd(), filename));
 }
 

--- a/src/cli-controller.js
+++ b/src/cli-controller.js
@@ -1,5 +1,5 @@
 import minimist from 'minimist';
-import {join, normalize, isAbsolute} from 'path';
+import {resolve} from 'path';
 import {readFileSync} from 'fs';
 import {
   compileToModule,
@@ -9,17 +9,9 @@ import {
   compileSchemaIDL
 } from './index';
 
-function normalizePath(filename) {
-  if (isAbsolute(filename)) {
-    return normalize(filename);
-  }
-
-  return normalize(join(process.cwd(), filename));
-}
-
 function splitFiles(files, schemaPath) {
-  const filenames = files.map(normalizePath);
-  const schema = normalizePath(schemaPath);
+  const filenames = files.map((path) => resolve(path));
+  const schema = resolve(schemaPath);
 
   const documents = filenames.filter((filename) => {
     return schema !== filename;
@@ -95,6 +87,6 @@ export default function run(argv) {
     documents,
     schemaCompiler,
     schema: schema && schemaFullPath,
-    outdir: normalizePath(outdir)
+    outdir: resolve(outdir)
   };
 }

--- a/src/cli-executor.js
+++ b/src/cli-executor.js
@@ -1,0 +1,3 @@
+import cli from './cli';
+
+cli(process.argv.slice(2));

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,30 +3,64 @@ import {relative, basename, dirname, join} from 'path';
 import mkdirp from 'mkdirp';
 import controller from './cli-controller';
 import usage from './usage';
+import fragmentFilesForDocument from './fragment-files-for-document';
 
-function read(path) {
-  // Double space after read to align with [WRITE]
-  console.log(`[READ]  ${path}`);
+function read(path, silent) {
+  if (!silent) {
+    // Double space after read to align with [WRITE]
+    console.log(`[READ]  ${path}`);
+  }
 
   return readFileSync(path).toString();
 }
 
-function write(path, body) {
-  console.log(`[WRITE] ${path}`);
+function write(path, body, silent) {
+  if (!silent) {
+    console.log(`[WRITE] ${path}`);
+  }
 
   return writeFileSync(path, body);
 }
 
-function readDocuments(documents) {
+function readDocuments(documents, silent) {
   return documents.map((path) => {
     return {
-      body: read(path),
+      body: read(path, silent),
       path
     };
   });
 }
 
-function compileDocuments({documentCode, documentCompiler, outdir}) {
+function concatBodies(files) {
+  return files.reduce((buffer, file) => {
+    return buffer + file.body;
+  }, '');
+}
+
+function concatenateAndMarkFragments(documentCode) {
+  return documentCode.map((document) => {
+    const fragmentFiles = fragmentFilesForDocument(document.path, document.body);
+
+    if (fragmentFiles.length) {
+      const fragments = documentCode.filter((possibleFragment) => {
+        return fragmentFiles.includes(possibleFragment.path);
+      });
+
+      fragments.forEach((fragment) => {
+        fragment.isFragment = true;
+      });
+
+      return {
+        body: concatBodies(fragments.concat(document)),
+        path: document.path
+      };
+    }
+
+    return document;
+  });
+}
+
+function compileDocuments({documentCode, documentCompiler, outdir, silent}) {
   const compiledDocuments = documentCode.map((document) => {
     const relativePath = relative(process.cwd(), document.path);
     const filename = basename(relativePath, '.graphql');
@@ -39,19 +73,18 @@ function compileDocuments({documentCode, documentCompiler, outdir}) {
     };
   });
 
-
   compiledDocuments.forEach((document) => {
     mkdirp.sync(dirname(document.path));
 
-    write(document.path, document.body);
+    write(document.path, document.body, silent);
   });
 
   return documentCode.map((document) => document.body);
 }
 
-function compileSchema({outdir, documentCode, schema, schemaCompiler}) {
+function compileSchema({outdir, documentCode, schema, schemaCompiler, silent}) {
   const documentBodies = documentCode.map((document) => document.body);
-  const schemaBody = read(schema);
+  const schemaBody = read(schema, silent);
   const relativeSchemaPath = relative(process.cwd(), schema);
   const extension = `.${schema.split('.').pop()}`;
   const filename = basename(relativeSchemaPath, extension);
@@ -59,11 +92,11 @@ function compileSchema({outdir, documentCode, schema, schemaCompiler}) {
   const outputPath = join(outdir, relativeDirectory, `${filename}.js`);
 
   return schemaCompiler(schemaBody, {documents: documentBodies}).then((body) => {
-    write(outputPath, body);
+    write(outputPath, body, silent);
   });
 }
 
-function run(args) {
+export default function cli(args, {silent = false} = {}) {
   const {
     documents,
     documentCompiler,
@@ -80,13 +113,17 @@ function run(args) {
 
   mkdirp.sync(outdir);
 
-  const documentCode = readDocuments(documents);
+  const rawDocumentCode = readDocuments(documents, silent);
+  const documentAndFragmentCode = concatenateAndMarkFragments(rawDocumentCode);
+  const documentCode = documentAndFragmentCode.filter((document) => {
+    return !document.isFragment;
+  });
 
-  compileDocuments({outdir, documentCode, documentCompiler});
+  compileDocuments({outdir, documentCode, documentCompiler, silent});
 
   if (schema && schemaCompiler) {
-    compileSchema({outdir, documentCode, schema, schemaCompiler});
+    return compileSchema({outdir, documentCode, schema, schemaCompiler, silent});
   }
-}
 
-run(process.argv.slice(2));
+  return Promise.resolve();
+}

--- a/src/find-undefined-fragments.js
+++ b/src/find-undefined-fragments.js
@@ -1,0 +1,19 @@
+import {parse, visit} from 'graphql/language';
+
+export default function findUndefinedFragments(document) {
+  const definitionNames = [];
+  const spreadNames = [];
+
+  visit(parse(document), {
+    FragmentDefinition(nodes) {
+      definitionNames.push(nodes.name.value);
+    },
+    FragmentSpread(nodes) {
+      spreadNames.push(nodes.name.value);
+    }
+  });
+
+  return spreadNames.filter((name) => {
+    return !definitionNames.includes(name);
+  });
+}

--- a/src/fragment-files-for-document.js
+++ b/src/fragment-files-for-document.js
@@ -1,0 +1,11 @@
+import {dirname, join} from 'path';
+import findUndefinedFragments from './find-undefined-fragments';
+
+export default function fragmentFilesForDocument(documentPath, document) {
+  const undefinedFragments = findUndefinedFragments(document);
+  const workingDirectory = dirname(documentPath);
+
+  return undefinedFragments.map((fragmentName) => {
+    return join(workingDirectory, `${fragmentName}.graphql`);
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,9 @@ export {
   compileOptimizedSchemaJson,
   compileOptimizedSchemaIDL
 } from './schema-compilers';
+export {
+  default as findUndefinedFragments
+} from './find-undefined-fragments';
+export {
+  default as fragmentFilesForDocument
+} from './fragment-files-for-document';

--- a/test/cli-integration-test.js
+++ b/test/cli-integration-test.js
@@ -1,0 +1,144 @@
+import assert from 'assert';
+import {join, normalize} from 'path';
+import {readdirSync, readFileSync} from 'fs';
+import tmp from 'tmp';
+import cli from '../src/cli';
+
+suite('cli-integration-test', () => {
+  let outdir;
+  let originalCwd;
+
+  suiteSetup(() => {
+    originalCwd = process.cwd();
+  });
+
+  suiteTeardown(() => {
+    process.chdir(originalCwd);
+  });
+
+  setup(() => {
+    tmp.setGracefulCleanup();
+    outdir = tmp.dirSync().name;
+  });
+
+  function assertFilesMatch(files) {
+    assert.equal(
+      readFileSync(files.output).toString(),
+      readFileSync(files.fixture).toString(),
+      `Output file: "${normalize(files.output)}" does not match fixture "${normalize(files.fixture)}"`
+    );
+  }
+
+  test('it can generate a set of graphql modules for a set of queries', () => {
+    process.chdir(join(originalCwd, 'test/fixtures/cli-integration/queries'));
+
+    return cli([
+      '--outdir',
+      outdir,
+      'query-one.graphql',
+      'sub-folder/query-two.graphql'
+    ], {silent: true}).then(() => {
+      assert.deepEqual(readdirSync(outdir), [
+        'query-one.js',
+        'sub-folder'
+      ]);
+      assert.deepEqual(readdirSync(join(outdir, 'sub-folder')), [
+        'query-two.js'
+      ]);
+
+      [{
+        output: join(outdir, 'query-one.js'),
+        fixture: join(process.cwd(), '../basic-output/query-one.js')
+      }, {
+        output: join(outdir, 'sub-folder/query-two.js'),
+        fixture: join(process.cwd(), '../basic-output/sub-folder/query-two.js')
+      }].forEach(assertFilesMatch);
+    });
+  });
+
+  test('it can generate a set of graphql modules for a set of queries and a schema', () => {
+    process.chdir(join(originalCwd, 'test/fixtures/cli-integration/queries'));
+
+    return cli([
+      '--outdir',
+      outdir,
+      '--schema',
+      'schema.graphql',
+      'query-one.graphql',
+      'sub-folder/query-two.graphql'
+    ], {silent: true}).then(() => {
+      assert.deepEqual(readdirSync(outdir), [
+        'query-one.js',
+        'schema.js',
+        'sub-folder'
+      ]);
+      assert.deepEqual(readdirSync(join(outdir, 'sub-folder')), [
+        'query-two.js'
+      ]);
+
+      [{
+        output: join(outdir, 'query-one.js'),
+        fixture: join(process.cwd(), '../basic-output/query-one.js')
+      }, {
+        output: join(outdir, 'schema.js'),
+        fixture: join(process.cwd(), '../basic-output/schema.js')
+      }, {
+        output: join(outdir, 'sub-folder/query-two.js'),
+        fixture: join(process.cwd(), '../basic-output/sub-folder/query-two.js')
+      }].forEach(assertFilesMatch);
+    });
+  });
+
+  test('it can generate and optimize a set of graphql modules for a set of queries and a schema', () => {
+    process.chdir(join(originalCwd, 'test/fixtures/cli-integration/queries'));
+
+    return cli([
+      '--optimize',
+      '--outdir',
+      outdir,
+      '--schema',
+      'schema.graphql',
+      'query-one.graphql',
+      'sub-folder/query-two.graphql'
+    ], {silent: true}).then(() => {
+      [{
+        output: join(outdir, 'query-one.js'),
+        fixture: join(process.cwd(), '../optimized-output/query-one.js')
+      }, {
+        output: join(outdir, 'schema.js'),
+        fixture: join(process.cwd(), '../optimized-output/schema.js')
+      }, {
+        output: join(outdir, 'sub-folder/query-two.js'),
+        fixture: join(process.cwd(), '../optimized-output/sub-folder/query-two.js')
+      }].forEach(assertFilesMatch);
+    });
+  });
+
+  test('it can concatenate fragments into queries with unresolved queries', () => {
+    process.chdir(join(originalCwd, 'test/fixtures/cli-integration/queries-with-fragments'));
+
+    return cli([
+      '--outdir',
+      outdir,
+      'query-one.graphql',
+      'sub-folder/query-two.graphql',
+      'ProductFragment.graphql'
+    ], {silent: true}).then(() => {
+      assert.deepEqual(readdirSync(outdir), [
+        'query-one.js',
+        'sub-folder'
+      ]);
+      assert.deepEqual(readdirSync(join(outdir, 'sub-folder')), [
+        'query-two.js'
+      ]);
+
+      [{
+        output: join(outdir, 'query-one.js'),
+        fixture: join(process.cwd(), '../concatenated-fragment-output/query-one.js')
+      }, {
+        output: join(outdir, 'sub-folder/query-two.js'),
+        fixture: join(process.cwd(), '../concatenated-fragment-output/sub-folder/query-two.js')
+      }].forEach(assertFilesMatch);
+    });
+  });
+});

--- a/test/find-undefined-fragments-test.js
+++ b/test/find-undefined-fragments-test.js
@@ -1,0 +1,61 @@
+import assert from 'assert';
+import findUndefinedFragments from '../src/find-undefined-fragments';
+
+suite('find-undefined-fragments-test', () => {
+  test('it can find fragments without definitions in a document', () => {
+    const undefinedFragments = findUndefinedFragments(`
+      query {
+        shop {
+          ...shopFragment
+        }
+
+        node(id: "1") {
+          ...productFragment
+          ...collectionFragment
+        }
+      }
+
+      fragment shopFragment on Shop {
+        name
+      }
+
+      fragment productFragment on Product {
+        ...productFragmentPartOne
+        ...productFragmentPartTwo
+      }
+
+      fragment productFragmentPartOne on Product {
+        name
+      }
+    `);
+
+    assert.deepEqual(undefinedFragments, [
+      'collectionFragment',
+      'productFragmentPartTwo'
+    ]);
+  });
+
+  test('it can handle documents with no undefined fragments', () => {
+    const undefinedFragments = findUndefinedFragments(`
+      query {
+        shop {
+          ...shopFragment
+        }
+
+        node(id: "1") {
+          ...productFragment
+        }
+      }
+
+      fragment shopFragment on Shop {
+        name
+      }
+
+      fragment productFragment on Product {
+        name
+      }
+    `);
+
+    assert.deepEqual(undefinedFragments, []);
+  });
+});

--- a/test/fixtures/cli-integration/basic-output/query-one.js
+++ b/test/fixtures/cli-integration/basic-output/query-one.js
@@ -1,0 +1,19 @@
+export default function query(client) {
+  const document = client.document();
+  const spreads = {};
+  spreads.ProductFragment = document.defineFragment("ProductFragment", "Product", root => {
+    root.add("id");
+    root.add("name");
+    root.add("price");
+  });
+  document.addQuery("FancyQuery", [client.variable("id", "ID!")], root => {
+    root.add("node", {
+      args: {
+        id: client.variable("id")
+      }
+    }, node => {
+      node.addFragment(spreads.ProductFragment);
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/basic-output/schema.js
+++ b/test/fixtures/cli-integration/basic-output/schema.js
@@ -1,0 +1,201 @@
+const Query = {
+  "name": "Query",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "node": "Node",
+    "shop": "Shop"
+  },
+  "implementsNode": false
+};
+
+const ID = {
+  "name": "ID",
+  "kind": "SCALAR"
+};
+
+const Node = {
+  "name": "Node",
+  "kind": "INTERFACE",
+  "fieldBaseTypes": {
+    "id": "ID"
+  },
+  "possibleTypes": ["Product"]
+};
+
+const Shop = {
+  "name": "Shop",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "address": "String"
+  },
+  "implementsNode": false
+};
+
+const String = {
+  "name": "String",
+  "kind": "SCALAR"
+};
+
+const __Schema = {
+  "name": "__Schema",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "types": "__Type",
+    "queryType": "__Type",
+    "mutationType": "__Type",
+    "subscriptionType": "__Type",
+    "directives": "__Directive"
+  },
+  "implementsNode": false
+};
+
+const __Type = {
+  "name": "__Type",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "kind": "__TypeKind",
+    "name": "String",
+    "description": "String",
+    "fields": "__Field",
+    "interfaces": "__Type",
+    "possibleTypes": "__Type",
+    "enumValues": "__EnumValue",
+    "inputFields": "__InputValue",
+    "ofType": "__Type"
+  },
+  "implementsNode": false
+};
+
+const __TypeKind = {
+  "name": "__TypeKind",
+  "kind": "ENUM"
+};
+
+const Boolean = {
+  "name": "Boolean",
+  "kind": "SCALAR"
+};
+
+const __Field = {
+  "name": "__Field",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "description": "String",
+    "args": "__InputValue",
+    "type": "__Type",
+    "isDeprecated": "Boolean",
+    "deprecationReason": "String"
+  },
+  "implementsNode": false
+};
+
+const __InputValue = {
+  "name": "__InputValue",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "description": "String",
+    "type": "__Type",
+    "defaultValue": "String"
+  },
+  "implementsNode": false
+};
+
+const __EnumValue = {
+  "name": "__EnumValue",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "description": "String",
+    "isDeprecated": "Boolean",
+    "deprecationReason": "String"
+  },
+  "implementsNode": false
+};
+
+const __Directive = {
+  "name": "__Directive",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "description": "String",
+    "locations": "__DirectiveLocation",
+    "args": "__InputValue",
+    "onOperation": "Boolean",
+    "onFragment": "Boolean",
+    "onField": "Boolean"
+  },
+  "implementsNode": false
+};
+
+const __DirectiveLocation = {
+  "name": "__DirectiveLocation",
+  "kind": "ENUM"
+};
+
+const Product = {
+  "name": "Product",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "id": "ID",
+    "name": "String",
+    "price": "Float"
+  },
+  "implementsNode": true
+};
+
+const Float = {
+  "name": "Float",
+  "kind": "SCALAR"
+};
+
+const Collection = {
+  "name": "Collection",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String",
+    "products": "Product"
+  },
+  "implementsNode": false
+};
+
+const Types = {
+  types: {}
+};
+Types.types["Query"] = Query;
+Types.types["ID"] = ID;
+Types.types["Node"] = Node;
+Types.types["Shop"] = Shop;
+Types.types["String"] = String;
+Types.types["__Schema"] = __Schema;
+Types.types["__Type"] = __Type;
+Types.types["__TypeKind"] = __TypeKind;
+Types.types["Boolean"] = Boolean;
+Types.types["__Field"] = __Field;
+Types.types["__InputValue"] = __InputValue;
+Types.types["__EnumValue"] = __EnumValue;
+Types.types["__Directive"] = __Directive;
+Types.types["__DirectiveLocation"] = __DirectiveLocation;
+Types.types["Product"] = Product;
+Types.types["Float"] = Float;
+Types.types["Collection"] = Collection;
+Types.queryType = "Query";
+Types.mutationType = null;
+Types.subscriptionType = null;
+
+function recursivelyFreezeObject(structure) {
+  Object.getOwnPropertyNames(structure).forEach(key => {
+    const value = structure[key];
+    if (value && typeof value === 'object') {
+      recursivelyFreezeObject(value);
+    }
+  });
+  Object.freeze(structure);
+  return structure;
+}
+
+var types = recursivelyFreezeObject(Types);
+
+export default types;

--- a/test/fixtures/cli-integration/basic-output/sub-folder/query-two.js
+++ b/test/fixtures/cli-integration/basic-output/sub-folder/query-two.js
@@ -1,0 +1,9 @@
+export default function query(client) {
+  const document = client.document();
+  document.addQuery(root => {
+    root.add("shop", shop => {
+      shop.add("name");
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/concatenated-fragment-output/query-one.js
+++ b/test/fixtures/cli-integration/concatenated-fragment-output/query-one.js
@@ -1,0 +1,19 @@
+export default function query(client) {
+  const document = client.document();
+  const spreads = {};
+  spreads.ProductFragment = document.defineFragment("ProductFragment", "Product", root => {
+    root.add("id");
+    root.add("name");
+    root.add("price");
+  });
+  document.addQuery("FancyQuery", [client.variable("id", "ID!")], root => {
+    root.add("node", {
+      args: {
+        id: client.variable("id")
+      }
+    }, node => {
+      node.addFragment(spreads.ProductFragment);
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/concatenated-fragment-output/sub-folder/query-two.js
+++ b/test/fixtures/cli-integration/concatenated-fragment-output/sub-folder/query-two.js
@@ -1,0 +1,9 @@
+export default function query(client) {
+  const document = client.document();
+  document.addQuery(root => {
+    root.add("shop", shop => {
+      shop.add("name");
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/optimized-output/query-one.js
+++ b/test/fixtures/cli-integration/optimized-output/query-one.js
@@ -1,0 +1,19 @@
+export default function query(client) {
+  const document = client.document();
+  const spreads = {};
+  spreads.ProductFragment = document.defineFragment("ProductFragment", "Product", root => {
+    root.add("id");
+    root.add("name");
+    root.add("price");
+  });
+  document.addQuery("FancyQuery", [client.variable("id", "ID!")], root => {
+    root.add("node", {
+      args: {
+        id: client.variable("id")
+      }
+    }, node => {
+      node.addFragment(spreads.ProductFragment);
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/optimized-output/schema.js
+++ b/test/fixtures/cli-integration/optimized-output/schema.js
@@ -1,0 +1,80 @@
+const Query = {
+  "name": "Query",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "node": "Node",
+    "shop": "Shop"
+  },
+  "implementsNode": false
+};
+
+const ID = {
+  "name": "ID",
+  "kind": "SCALAR"
+};
+
+const Node = {
+  "name": "Node",
+  "kind": "INTERFACE",
+  "fieldBaseTypes": {},
+  "possibleTypes": ["Product"]
+};
+
+const Shop = {
+  "name": "Shop",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "name": "String"
+  },
+  "implementsNode": false
+};
+
+const String = {
+  "name": "String",
+  "kind": "SCALAR"
+};
+
+const Product = {
+  "name": "Product",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "id": "ID",
+    "name": "String",
+    "price": "Float"
+  },
+  "implementsNode": true
+};
+
+const Float = {
+  "name": "Float",
+  "kind": "SCALAR"
+};
+
+const Types = {
+  types: {}
+};
+Types.types["Query"] = Query;
+Types.types["ID"] = ID;
+Types.types["Node"] = Node;
+Types.types["Shop"] = Shop;
+Types.types["String"] = String;
+Types.types["Product"] = Product;
+Types.types["Float"] = Float;
+Types.queryType = "Query";
+Types.mutationType = null;
+Types.subscriptionType = null;
+
+function recursivelyFreezeObject(structure) {
+  Object.getOwnPropertyNames(structure).forEach(key => {
+    const value = structure[key];
+    if (value && typeof value === 'object') {
+      recursivelyFreezeObject(value);
+    }
+  });
+  Object.freeze(structure);
+  return structure;
+}
+
+var types = recursivelyFreezeObject(Types);
+
+export default types;

--- a/test/fixtures/cli-integration/optimized-output/sub-folder/query-two.js
+++ b/test/fixtures/cli-integration/optimized-output/sub-folder/query-two.js
@@ -1,0 +1,9 @@
+export default function query(client) {
+  const document = client.document();
+  document.addQuery(root => {
+    root.add("shop", shop => {
+      shop.add("name");
+    });
+  });
+  return document;
+}

--- a/test/fixtures/cli-integration/queries-with-fragments/ProductFragment.graphql
+++ b/test/fixtures/cli-integration/queries-with-fragments/ProductFragment.graphql
@@ -1,0 +1,5 @@
+fragment ProductFragment on Product {
+  id
+  name
+  price
+}

--- a/test/fixtures/cli-integration/queries-with-fragments/query-one.graphql
+++ b/test/fixtures/cli-integration/queries-with-fragments/query-one.graphql
@@ -1,0 +1,5 @@
+query FancyQuery($id: ID!) {
+  node(id: $id) {
+    ...ProductFragment
+  }
+}

--- a/test/fixtures/cli-integration/queries-with-fragments/schema.graphql
+++ b/test/fixtures/cli-integration/queries-with-fragments/schema.graphql
@@ -1,0 +1,24 @@
+interface Node {
+  id: ID!
+}
+
+type Product implements Node {
+  id: ID!
+  name: String!
+  price: Float!
+}
+
+type Shop {
+  name: String!
+  address: String!
+}
+
+type Collection {
+  name: String!
+  products: [Product!]!
+}
+
+type Query {
+  node(id: ID!): Node
+  shop: Shop!
+}

--- a/test/fixtures/cli-integration/queries-with-fragments/sub-folder/query-two.graphql
+++ b/test/fixtures/cli-integration/queries-with-fragments/sub-folder/query-two.graphql
@@ -1,0 +1,5 @@
+query {
+  shop {
+    name
+  }
+}

--- a/test/fixtures/cli-integration/queries/ProductFragment.graphql
+++ b/test/fixtures/cli-integration/queries/ProductFragment.graphql
@@ -1,0 +1,5 @@
+fragment ProductFragment on Product {
+  id
+  name
+  price
+}

--- a/test/fixtures/cli-integration/queries/query-one.graphql
+++ b/test/fixtures/cli-integration/queries/query-one.graphql
@@ -1,0 +1,11 @@
+fragment ProductFragment on Product {
+  id
+  name
+  price
+}
+
+query FancyQuery($id: ID!) {
+  node(id: $id) {
+    ...ProductFragment
+  }
+}

--- a/test/fixtures/cli-integration/queries/schema.graphql
+++ b/test/fixtures/cli-integration/queries/schema.graphql
@@ -1,0 +1,24 @@
+interface Node {
+  id: ID!
+}
+
+type Product implements Node {
+  id: ID!
+  name: String!
+  price: Float!
+}
+
+type Shop {
+  name: String!
+  address: String!
+}
+
+type Collection {
+  name: String!
+  products: [Product!]!
+}
+
+type Query {
+  node(id: ID!): Node
+  shop: Shop!
+}

--- a/test/fixtures/cli-integration/queries/sub-folder/query-two.graphql
+++ b/test/fixtures/cli-integration/queries/sub-folder/query-two.graphql
@@ -1,0 +1,5 @@
+query {
+  shop {
+    name
+  }
+}

--- a/test/fragment-files-for-document-test.js
+++ b/test/fragment-files-for-document-test.js
@@ -1,0 +1,70 @@
+import assert from 'assert';
+import {join} from 'path';
+import fragmentFilesForDocument from '../src/fragment-files-for-document';
+
+suite('fragment-files-for-document-test', () => {
+  test('it can resolve fragment files given a document and a file path', () => {
+    const queryWithUndefinedFragments = `
+      query {
+        shop {
+          ...shopFragment
+        }
+
+        node(id: "1") {
+          ...productFragment
+          ...collectionFragment
+        }
+      }
+
+      fragment shopFragment on Shop {
+        name
+      }
+
+      fragment productFragment on Product {
+        ...productFragmentPartOne
+        ...productFragmentPartTwo
+      }
+
+      fragment productFragmentPartOne on Product {
+        name
+      }
+    `;
+
+    const queryPath = join(process.cwd(), 'queries', 'has-undefined-fragments.graphql');
+
+    const undefinedFgramentPaths = fragmentFilesForDocument(queryPath, queryWithUndefinedFragments);
+
+    assert.deepEqual(undefinedFgramentPaths, [
+      join(process.cwd(), 'queries', 'collectionFragment.graphql'),
+      join(process.cwd(), 'queries', 'productFragmentPartTwo.graphql')
+    ]);
+  });
+
+  test('it can handle documents with no undefined fragments', () => {
+    const query = `
+      query {
+        shop {
+          ...shopFragment
+        }
+
+        node(id: "1") {
+          ...productFragment
+        }
+      }
+
+      fragment shopFragment on Shop {
+        name
+      }
+
+      fragment productFragment on Product {
+        name
+      }
+    `;
+
+    const queryPath = join(process.cwd(), 'queries', 'has-only-defined-fragments.graphql');
+
+    const fragmentPaths = fragmentFilesForDocument(queryPath, query);
+
+    assert.deepEqual(fragmentPaths, []);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,6 +2812,12 @@ tmp@0.0.29:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"


### PR DESCRIPTION
The pattern that's used is looking in the same directory as the graphql file for a file named the same as the fragment in document.

Example:

```graphql
query {
  node(id: "abc123") {
    ...ProductFragment
  }
}
```

Will search for a document passed in that lives in the same directory and has the name `ProductFragment.graphl`.

This PR also includes the functions required to search for undefined fragments and find the names of matching fragment files for any document. These functions will likely be useful in any plugins building on this functionality.